### PR TITLE
Preserve scroll position when changing platform

### DIFF
--- a/sphinxcontrib/platformpicker.js
+++ b/sphinxcontrib/platformpicker.js
@@ -1,6 +1,4 @@
 $(function() {
-    var top_sel = {}
-
     $('.platform-picker').each(function() {
         var selector = $('<ul />', { class: 'platform-selector' });
         $('.platform-choice', this).eq(0).before(selector);
@@ -29,6 +27,9 @@ $(function() {
         $('li', selector).click(function(event) {
             event.preventDefault();
 
+            const startPosition = $(this).offset();
+            const startScroll = window.scrollY;
+
             $('.platform-selector li').removeClass('selected');
             $('.platform-choice').hide();
 
@@ -46,6 +47,11 @@ $(function() {
                     });
                 }
             });
+
+            const newPosition = $(this).offset();
+            const scrollOffset = newPosition.top - startPosition.top;
+
+            window.scrollTo({ top: startScroll + scrollOffset, behavior: "instant" });
         });
     });
 });


### PR DESCRIPTION
Currently, the page jumps around a lot while changing the selected platform. This PR makes it so the platform picker remains on the same spot on the screen after a new platform is selected. This prevents the page from jumping around too hard and allows the user to roughly keep their scroll position while they switch platform.

[Screencast from 2024-08-21 14-27-16.webm](https://github.com/user-attachments/assets/80e613f1-d151-4bd8-b8dc-e3c670f6a252)

Closes https://github.com/amaranth-lang/amaranth/issues/1484